### PR TITLE
docs: clarify optionality of api prefix

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ aasRepository.getAASInterface("globalUniqueId").put(aas);
 
 There are several classes that are central to the library. 
 An instance of them represents an AAS service. All of these interfaces can be instantiated using a `baseUri`. 
-This `baseUri` should include the domain and end on `api/v3.0`. For example: `https://www.example.org/api/v3.0`.
+This `baseUri` should include the domain and can contain a path prefix such as `api/v3.0`. For example: `https://www.example.org/api/v3.0`.
 Optionally, the interfaces can be instantiated with strings for user and password for basic authentication or 
 with a user defined http-client for more advanced customization.
 


### PR DESCRIPTION
The README is a bit unclear about the previously mandatory path prefix /api/v3.0, this PR attempts to clarify this.

/api/v3.0 is still used in a lot of the test cases, but as it is a valid path prefix, I think they don't need to be modified.