### PR TITLE
feature: flexible authentication

### DIFF
--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBased.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBased.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2024 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.client.http;
+
+import java.io.IOException;
+import java.net.Authenticator;
+import java.net.CookieHandler;
+import java.net.ProxySelector;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.util.Optional;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.function.Supplier;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLParameters;
+
+import static java.net.http.HttpRequest.BodyPublishers.noBody;
+
+
+/**
+ * HttpClient decorator adding to each request an authorization header given by a supplier.
+ */
+public class HttpClientTokenBased extends HttpClient {
+    private static final String AUTHORIZATION = "Authorization";
+
+    private final HttpClient impl;
+    private final Supplier<String> authSupplier;
+
+    public HttpClientTokenBased(HttpClient httpClient, Supplier<String> authSupplier) {
+        this.authSupplier = authSupplier;
+        this.impl = httpClient;
+    }
+
+
+    @Override
+    public Optional<CookieHandler> cookieHandler() {
+        return impl.cookieHandler();
+    }
+
+
+    @Override
+    public Optional<Duration> connectTimeout() {
+        return impl.connectTimeout();
+    }
+
+
+    @Override
+    public Redirect followRedirects() {
+        return impl.followRedirects();
+    }
+
+
+    @Override
+    public Optional<ProxySelector> proxy() {
+        return impl.proxy();
+    }
+
+
+    @Override
+    public SSLContext sslContext() {
+        return impl.sslContext();
+    }
+
+
+    @Override
+    public SSLParameters sslParameters() {
+        return impl.sslParameters();
+    }
+
+
+    @Override
+    public Optional<Authenticator> authenticator() {
+        return impl.authenticator();
+    }
+
+
+    @Override
+    public HttpClient.Version version() {
+        return impl.version();
+    }
+
+
+    @Override
+    public Optional<Executor> executor() {
+        return impl.executor();
+    }
+
+
+    @Override
+    public <T> HttpResponse<T> send(HttpRequest req, HttpResponse.BodyHandler<T> responseBodyHandler) throws IOException, InterruptedException {
+        return impl.send(decorate(req), responseBodyHandler);
+    }
+
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest req, HttpResponse.BodyHandler<T> responseBodyHandler) {
+        return impl.sendAsync(decorate(req), responseBodyHandler);
+    }
+
+
+    @Override
+    public <T> CompletableFuture<HttpResponse<T>> sendAsync(HttpRequest req,
+                                                            HttpResponse.BodyHandler<T> responseBodyHandler,
+                                                            HttpResponse.PushPromiseHandler<T> pushPromiseHandler) {
+        return impl.sendAsync(decorate(req), responseBodyHandler, pushPromiseHandler);
+    }
+
+
+    private HttpRequest decorate(HttpRequest request) {
+        HttpRequest.Builder decoratedRequestBuilder = HttpRequest.newBuilder()
+                .uri(request.uri())
+                .header(AUTHORIZATION, authSupplier.get())
+                .method(request.method(), request.bodyPublisher().orElse(noBody()))
+                .expectContinue(request.expectContinue());
+
+        // Add existing headers
+        request.headers().map()
+                .forEach((key, values) -> values.forEach(value -> decoratedRequestBuilder.header(key, value)));
+
+        // Optional settings
+        request.version().ifPresent(decoratedRequestBuilder::version);
+        request.timeout().ifPresent(decoratedRequestBuilder::timeout);
+        return decoratedRequestBuilder.build();
+    }
+}

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBased.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBased.java
@@ -124,9 +124,11 @@ public class HttpClientTokenBased extends HttpClient {
     private HttpRequest decorate(HttpRequest request) {
         HttpRequest.Builder decoratedRequestBuilder = HttpRequest.newBuilder()
                 .uri(request.uri())
-                .header(AUTHORIZATION, authSupplier.get())
                 .method(request.method(), request.bodyPublisher().orElse(noBody()))
                 .expectContinue(request.expectContinue());
+
+        Optional.ofNullable(authSupplier.get())
+                .ifPresent(auth -> decoratedRequestBuilder.header(AUTHORIZATION, auth));
 
         // Add existing headers
         request.headers().map()

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -221,23 +221,8 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<AASBasicDiscoveryInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public AASBasicDiscoveryInterface buildConcrete() {
+        protected AASBasicDiscoveryInterface buildConcrete() {
             return new AASBasicDiscoveryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -20,7 +20,8 @@ import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
 import de.fraunhofer.iosb.ilt.faaast.client.query.AASBasicDiscoverySearchCriteria;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpRequestHelper;
 import de.fraunhofer.iosb.ilt.faaast.client.util.QueryHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.DeserializationException;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.json.JsonApiDeserializer;
@@ -99,7 +100,7 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public AASBasicDiscoveryInterface(URI endpoint, boolean trustAllCertificates) {
-        super(resolve(endpoint, LOOKUP_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(resolve(endpoint, LOOKUP_PATH), trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -139,11 +140,11 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
         });
 
         AASBasicDiscoverySearchCriteria assetIds = new AASBasicDiscoverySearchCriteria.Builder().assetIds(assetIdentificationList).build();
-        HttpRequest request = HttpHelper.createGetRequest(
+        HttpRequest request = HttpRequestHelper.createGetRequest(
                 resolve(QueryHelper.apply(
                         null, Content.DEFAULT, QueryModifier.DEFAULT, pagingInfo, assetIds)),
                 authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
             return deserializePage(response.body(), String.class);
@@ -196,11 +197,11 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
      * @throws ConnectivityException if the connection to the server cannot be established
      */
     public List<SpecificAssetId> createAssetLinks(List<SpecificAssetId> assetLinks, String aasIdentifier) throws StatusCodeException, ConnectivityException {
-        HttpRequest request = HttpHelper.createPostRequest(
+        HttpRequest request = HttpRequestHelper.createPostRequest(
                 resolve(QueryHelper.apply(idPath(aasIdentifier), Content.DEFAULT, QueryModifier.DEFAULT)),
                 authenticationHeaderProvider.get(),
                 serializeEntity(assetLinks));
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.POST, response, HttpStatus.OK);
         try {
             return new JsonApiDeserializer().readList(response.body(), SpecificAssetId.class);
@@ -230,7 +231,7 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
         delete(idPath(aasIdentifier));
     }
 
-    public static class Builder extends BaseBuilder<AASBasicDiscoveryInterface, Builder> {
+    public static class Builder extends AbstractBuilder<AASBasicDiscoveryInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -105,18 +105,6 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Discovery Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public AASBasicDiscoveryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, LOOKUP_PATH), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Returns a list of Asset Administration Shell IDs linked to specific asset identifiers or the global asset ID.
      *
      * @param assetLinks A list of specific asset identifiers. Search for the global asset ID is supported by setting "name"

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -237,13 +237,6 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = endpoint;
-            return getSelf();
-        }
-
-
-        @Override
         public AASBasicDiscoveryInterface buildConcrete() {
             return new AASBasicDiscoveryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -54,6 +54,11 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
 
     private static final String LOOKUP_PATH = "/lookup/shells";
 
+    private AASBasicDiscoveryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, LOOKUP_PATH), httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Discovery Interface.
      *
@@ -225,4 +230,33 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
         delete(idPath(aasIdentifier));
     }
 
+    public static class Builder extends BaseBuilder<AASBasicDiscoveryInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
+
+
+        @Override
+        public AASBasicDiscoveryInterface buildConcrete() {
+            return new AASBasicDiscoveryInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
+    }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -40,7 +40,6 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Supplier;
 
 
 /**
@@ -54,11 +53,6 @@ import java.util.function.Supplier;
 public class AASBasicDiscoveryInterface extends BaseInterface {
 
     private static final String LOOKUP_PATH = "/lookup/shells";
-
-    private AASBasicDiscoveryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, LOOKUP_PATH), httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Discovery Interface.
@@ -130,8 +124,7 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
         AASBasicDiscoverySearchCriteria assetIds = new AASBasicDiscoverySearchCriteria.Builder().assetIds(assetIdentificationList).build();
         HttpRequest request = HttpRequestHelper.createGetRequest(
                 resolve(QueryHelper.apply(
-                        null, Content.DEFAULT, QueryModifier.DEFAULT, pagingInfo, assetIds)),
-                authenticationHeaderProvider.get());
+                        null, Content.DEFAULT, QueryModifier.DEFAULT, pagingInfo, assetIds)));
         HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
@@ -185,9 +178,7 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
      * @throws ConnectivityException if the connection to the server cannot be established
      */
     public List<SpecificAssetId> createAssetLinks(List<SpecificAssetId> assetLinks, String aasIdentifier) throws StatusCodeException, ConnectivityException {
-        HttpRequest request = HttpRequestHelper.createPostRequest(
-                resolve(QueryHelper.apply(idPath(aasIdentifier), Content.DEFAULT, QueryModifier.DEFAULT)),
-                authenticationHeaderProvider.get(),
+        HttpRequest request = HttpRequestHelper.createPostRequest(resolve(QueryHelper.apply(idPath(aasIdentifier), Content.DEFAULT, QueryModifier.DEFAULT)),
                 serializeEntity(assetLinks));
         HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.POST, response, HttpStatus.OK);
@@ -223,7 +214,7 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
 
         @Override
         protected AASBasicDiscoveryInterface buildConcrete() {
-            return new AASBasicDiscoveryInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new AASBasicDiscoveryInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -256,7 +256,7 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
 
         @Override
         public AASBasicDiscoveryInterface buildConcrete() {
-            return new AASBasicDiscoveryInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new AASBasicDiscoveryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASBasicDiscoveryInterface.java
@@ -39,6 +39,7 @@ import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.function.Supplier;
 
 
 /**
@@ -98,6 +99,18 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
 
 
     /**
+     * Creates a new Discovery Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public AASBasicDiscoveryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, LOOKUP_PATH), authenticationHeaderProvider);
+    }
+
+
+    /**
      * Returns a list of Asset Administration Shell IDs linked to specific asset identifiers or the global asset ID.
      *
      * @param assetLinks A list of specific asset identifiers. Search for the global asset ID is supported by setting "name"
@@ -123,7 +136,8 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
         AASBasicDiscoverySearchCriteria assetIds = new AASBasicDiscoverySearchCriteria.Builder().assetIds(assetIdentificationList).build();
         HttpRequest request = HttpHelper.createGetRequest(
                 resolve(QueryHelper.apply(
-                        null, Content.DEFAULT, QueryModifier.DEFAULT, pagingInfo, assetIds)));
+                        null, Content.DEFAULT, QueryModifier.DEFAULT, pagingInfo, assetIds)),
+                authenticationHeaderProvider.get());
         HttpResponse<String> response = HttpHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
@@ -177,7 +191,9 @@ public class AASBasicDiscoveryInterface extends BaseInterface {
      * @throws ConnectivityException if the connection to the server cannot be established
      */
     public List<SpecificAssetId> createAssetLinks(List<SpecificAssetId> assetLinks, String aasIdentifier) throws StatusCodeException, ConnectivityException {
-        HttpRequest request = HttpHelper.createPostRequest(resolve(QueryHelper.apply(idPath(aasIdentifier), Content.DEFAULT, QueryModifier.DEFAULT)),
+        HttpRequest request = HttpHelper.createPostRequest(
+                resolve(QueryHelper.apply(idPath(aasIdentifier), Content.DEFAULT, QueryModifier.DEFAULT)),
+                authenticationHeaderProvider.get(),
                 serializeEntity(assetLinks));
         HttpResponse<String> response = HttpHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.POST, response, HttpStatus.OK);

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -398,23 +398,8 @@ public class AASInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<AASInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public AASInterface buildConcrete() {
+        protected AASInterface buildConcrete() {
             return new AASInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -26,6 +26,7 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
+import java.util.function.Supplier;
 
 import de.fraunhofer.iosb.ilt.faaast.service.model.exception.InvalidRequestException;
 import org.eclipse.digitaltwin.aas4j.v3.model.*;
@@ -83,6 +84,18 @@ public class AASInterface extends BaseInterface {
      */
     public AASInterface(URI endpoint, boolean trustAllCertificates) {
         super(endpoint, trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+    }
+
+
+    /**
+     * Creates a new Asset Administration Shell Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public AASInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(endpoint, authenticationHeaderProvider);
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -26,7 +26,6 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
-import java.util.function.Supplier;
 
 import de.fraunhofer.iosb.ilt.faaast.service.model.exception.InvalidRequestException;
 import org.eclipse.digitaltwin.aas4j.v3.model.*;
@@ -42,11 +41,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.*;
  * </p>
  */
 public class AASInterface extends BaseInterface {
-
-    private AASInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(endpoint, httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Asset Administration Shell Interface.
@@ -400,7 +394,7 @@ public class AASInterface extends BaseInterface {
 
         @Override
         protected AASInterface buildConcrete() {
-            return new AASInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new AASInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -17,9 +17,9 @@ package de.fraunhofer.iosb.ilt.faaast.client.interfaces;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.InMemoryFile;
 import de.fraunhofer.iosb.ilt.faaast.service.model.TypedInMemoryFile;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.Content;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
@@ -88,7 +88,7 @@ public class AASInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public AASInterface(URI endpoint, boolean trustAllCertificates) {
-        super(endpoint, trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(endpoint, trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -408,7 +408,7 @@ public class AASInterface extends BaseInterface {
         return assetInfoPath() + "/thumbnail";
     }
 
-    public static class Builder extends BaseBuilder<AASInterface, Builder> {
+    public static class Builder extends AbstractBuilder<AASInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -434,7 +434,7 @@ public class AASInterface extends BaseInterface {
 
         @Override
         public AASInterface buildConcrete() {
-            return new AASInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new AASInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -93,18 +93,6 @@ public class AASInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Asset Administration Shell Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public AASInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(endpoint, authenticationHeaderProvider);
-    }
-
-
-    /**
      * Retrieves the Asset Administration Shell (AAS) from the server.
      *
      * @return The requested Asset Administration Shell object

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -43,6 +43,11 @@ import org.eclipse.digitaltwin.aas4j.v3.model.*;
  */
 public class AASInterface extends BaseInterface {
 
+    private AASInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(endpoint, httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Asset Administration Shell Interface.
      *
@@ -403,4 +408,33 @@ public class AASInterface extends BaseInterface {
         return assetInfoPath() + "/thumbnail";
     }
 
+    public static class Builder extends BaseBuilder<AASInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
+
+
+        @Override
+        public AASInterface buildConcrete() {
+            return new AASInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
+    }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASInterface.java
@@ -414,13 +414,6 @@ public class AASInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = endpoint;
-            return getSelf();
-        }
-
-
-        @Override
         public AASInterface buildConcrete() {
             return new AASInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -27,7 +27,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShe
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
-import java.util.function.Supplier;
 
 
 /**
@@ -43,11 +42,6 @@ import java.util.function.Supplier;
 public class AASRegistryInterface extends BaseInterface {
 
     private static final String API_PATH = "/shell-descriptors";
-
-    private AASRegistryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Asset Administration Shell Registry Interface.
@@ -263,7 +257,7 @@ public class AASRegistryInterface extends BaseInterface {
 
         @Override
         protected AASRegistryInterface buildConcrete() {
-            return new AASRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new AASRegistryInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -297,7 +297,7 @@ public class AASRegistryInterface extends BaseInterface {
 
         @Override
         public AASRegistryInterface buildConcrete() {
-            return new AASRegistryInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new AASRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -277,13 +277,6 @@ public class AASRegistryInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = resolve(endpoint, API_PATH);
-            return getSelf();
-        }
-
-
-        @Override
         public AASRegistryInterface buildConcrete() {
             return new AASRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -94,18 +94,6 @@ public class AASRegistryInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Asset Administration Shell Registry Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public AASRegistryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Returns all Asset Administration Shell Descriptors in a List.
      *
      * @return List containing all Asset Administration Shell Descriptors

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -261,23 +261,8 @@ public class AASRegistryInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<AASRegistryInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public AASRegistryInterface buildConcrete() {
+        protected AASRegistryInterface buildConcrete() {
             return new AASRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -44,6 +44,11 @@ public class AASRegistryInterface extends BaseInterface {
 
     private static final String API_PATH = "/shell-descriptors";
 
+    private AASRegistryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Asset Administration Shell Registry Interface.
      *
@@ -264,5 +269,35 @@ public class AASRegistryInterface extends BaseInterface {
      */
     public SubmodelRegistryInterface getSubmodelRegistryInterface(String aasIdentifier) {
         return new SubmodelRegistryInterface(resolve(idPath(aasIdentifier)));
+    }
+
+    public static class Builder extends BaseBuilder<AASRegistryInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = resolve(endpoint, API_PATH);
+            return getSelf();
+        }
+
+
+        @Override
+        public AASRegistryInterface buildConcrete() {
+            return new AASRegistryInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -17,7 +17,7 @@ package de.fraunhofer.iosb.ilt.faaast.client.interfaces;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.query.AASDescriptorSearchCriteria;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.Content;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
@@ -89,7 +89,7 @@ public class AASRegistryInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public AASRegistryInterface(URI endpoint, boolean trustAllCertificates) {
-        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -271,7 +271,7 @@ public class AASRegistryInterface extends BaseInterface {
         return new SubmodelRegistryInterface(resolve(idPath(aasIdentifier)));
     }
 
-    public static class Builder extends BaseBuilder<AASRegistryInterface, Builder> {
+    public static class Builder extends AbstractBuilder<AASRegistryInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRegistryInterface.java
@@ -27,6 +27,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultAssetAdministrationShe
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
+import java.util.function.Supplier;
 
 
 /**
@@ -84,6 +85,18 @@ public class AASRegistryInterface extends BaseInterface {
      */
     public AASRegistryInterface(URI endpoint, boolean trustAllCertificates) {
         super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+    }
+
+
+    /**
+     * Creates a new Asset Administration Shell Registry Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public AASRegistryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -42,6 +42,11 @@ public class AASRepositoryInterface extends BaseInterface {
 
     private static final String API_PATH = "/shells";
 
+    private AASRepositoryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Asset Administration Shell Repository Interface using a custom HTTP client.
      *
@@ -330,5 +335,35 @@ public class AASRepositoryInterface extends BaseInterface {
      */
     public AASInterface getAASInterface(String aasIdentifier) {
         return new AASInterface(resolve(idPath(aasIdentifier)), httpClient);
+    }
+
+    public static class Builder extends BaseBuilder<AASRepositoryInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = resolve(endpoint, API_PATH);
+            return getSelf();
+        }
+
+
+        @Override
+        public AASRepositoryInterface buildConcrete() {
+            return new AASRepositoryInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -363,7 +363,7 @@ public class AASRepositoryInterface extends BaseInterface {
 
         @Override
         public AASRepositoryInterface buildConcrete() {
-            return new AASRepositoryInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new AASRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -17,7 +17,7 @@ package de.fraunhofer.iosb.ilt.faaast.client.interfaces;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.query.AASSearchCriteria;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.Content;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
@@ -87,7 +87,7 @@ public class AASRepositoryInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public AASRepositoryInterface(URI endpoint, boolean trustAllCertificates) {
-        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -337,7 +337,7 @@ public class AASRepositoryInterface extends BaseInterface {
         return new AASInterface(resolve(idPath(aasIdentifier)), httpClient);
     }
 
-    public static class Builder extends BaseBuilder<AASRepositoryInterface, Builder> {
+    public static class Builder extends AbstractBuilder<AASRepositoryInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -92,18 +92,6 @@ public class AASRepositoryInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Asset Administration Shell Repository Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public AASRepositoryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Retrieves all Asset Administration Shells.
      *
      * @return A list of all Asset Administration Shells

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -27,7 +27,6 @@ import java.net.http.HttpClient;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
-import java.util.function.Supplier;
 
 
 /**
@@ -41,11 +40,6 @@ import java.util.function.Supplier;
 public class AASRepositoryInterface extends BaseInterface {
 
     private static final String API_PATH = "/shells";
-
-    private AASRepositoryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Asset Administration Shell Repository Interface using a custom HTTP client.
@@ -329,7 +323,7 @@ public class AASRepositoryInterface extends BaseInterface {
 
         @Override
         protected AASRepositoryInterface buildConcrete() {
-            return new AASRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new AASRepositoryInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -343,13 +343,6 @@ public class AASRepositoryInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = resolve(endpoint, API_PATH);
-            return getSelf();
-        }
-
-
-        @Override
         public AASRepositoryInterface buildConcrete() {
             return new AASRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -27,6 +27,7 @@ import java.net.http.HttpClient;
 import java.util.List;
 import org.eclipse.digitaltwin.aas4j.v3.model.AssetAdministrationShell;
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
+import java.util.function.Supplier;
 
 
 /**
@@ -82,6 +83,18 @@ public class AASRepositoryInterface extends BaseInterface {
      */
     public AASRepositoryInterface(URI endpoint, boolean trustAllCertificates) {
         super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+    }
+
+
+    /**
+     * Creates a new Asset Administration Shell Repository Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public AASRepositoryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/AASRepositoryInterface.java
@@ -327,23 +327,8 @@ public class AASRepositoryInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<AASRepositoryInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public AASRepositoryInterface buildConcrete() {
+        protected AASRepositoryInterface buildConcrete() {
             return new AASRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
@@ -1055,14 +1055,6 @@ public abstract class BaseInterface {
         protected Supplier<String> authenticationHeaderProvider = NO_OP_AUTH_HEADER_PROVIDER;
 
         /**
-         * Get a new instance of this builder type.
-         *
-         * @return A new instance of this builder type.
-         */
-        public abstract B newInstance();
-
-
-        /**
          * Supply a custom HttpClient.Builder.
          *
          * @param builder Custom HttpClient.Builder
@@ -1070,7 +1062,7 @@ public abstract class BaseInterface {
          */
         public final B customHttpClientBuilder(HttpClient.Builder builder) {
             this.httpClientBuilder = builder;
-            return getSelf();
+            return self();
         }
 
 
@@ -1082,7 +1074,7 @@ public abstract class BaseInterface {
          */
         public final B endpoint(URI endpoint) {
             this.endpoint = endpoint;
-            return getSelf();
+            return self();
         }
 
 
@@ -1097,7 +1089,7 @@ public abstract class BaseInterface {
          */
         public final B useTrustAllHttpClient() {
             HttpClientHelper.makeTrustAllCertificates(this.httpClientBuilder);
-            return getSelf();
+            return self();
         }
 
 
@@ -1110,7 +1102,7 @@ public abstract class BaseInterface {
          */
         public final B useBasicAuthentication(String username, String password) {
             HttpClientHelper.addBasicAuthentication(this.httpClientBuilder, username, password);
-            return getSelf();
+            return self();
         }
 
 
@@ -1130,7 +1122,7 @@ public abstract class BaseInterface {
          */
         public final B authenticationHeaderProvider(Supplier<String> authenticationHeaderProvider) {
             this.authenticationHeaderProvider = authenticationHeaderProvider;
-            return getSelf();
+            return self();
         }
 
 
@@ -1141,14 +1133,17 @@ public abstract class BaseInterface {
          */
         public final I build() {
             validate();
-            return getSelf().buildConcrete();
+            return self().buildConcrete();
         }
 
 
-        protected abstract B getSelf();
-
-
         protected abstract I buildConcrete();
+
+
+        @SuppressWarnings("unchecked")
+        protected final B self() {
+            return (B) this;
+        }
 
 
         protected final HttpClient httpClient() {

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
@@ -28,7 +28,8 @@ import de.fraunhofer.iosb.ilt.faaast.client.exception.UnsupportedStatusCodeExcep
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
 import de.fraunhofer.iosb.ilt.faaast.client.query.SearchCriteria;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpRequestHelper;
 import de.fraunhofer.iosb.ilt.faaast.client.util.QueryHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.DeserializationException;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.SerializationException;
@@ -126,7 +127,7 @@ public abstract class BaseInterface {
      * @param password String to allow for basic authentication
      */
     protected BaseInterface(URI endpoint, String user, String password) {
-        this(endpoint, HttpHelper.newUsernamePasswordClient(user, password));
+        this(endpoint, HttpClientHelper.newUsernamePasswordClient(user, password));
     }
 
 
@@ -137,7 +138,7 @@ public abstract class BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     protected BaseInterface(URI endpoint, boolean trustAllCertificates) {
-        this(endpoint, trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        this(endpoint, trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -281,8 +282,8 @@ public abstract class BaseInterface {
      * @throws InvalidPayloadException if deserializing the payload fails
      */
     protected <T> T get(String path, QueryModifier modifier, Content content, Class<T> responseType) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier)), authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier)), authenticationHeaderProvider.get());
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         return parseBody(response, responseType);
     }
@@ -301,8 +302,8 @@ public abstract class BaseInterface {
      * @throws InvalidPayloadException if deserializing the payload fails
      */
     protected <T extends ElementValue> T getValue(String path, QueryModifier modifier, TypeInfo<?> typeInfo) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createGetRequest(resolve(QueryHelper.apply(path, Content.VALUE, modifier)), authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, Content.VALUE, modifier)), authenticationHeaderProvider.get());
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
             return new JsonApiDeserializer().readValue(response.body(), typeInfo);
@@ -321,11 +322,11 @@ public abstract class BaseInterface {
      * @throws StatusCodeException if HTTP request returns invalid status code
      */
     protected InMemoryFile getFile(String path) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createGetRequest(resolve(QueryHelper.apply(path, Content.DEFAULT, QueryModifier.DEFAULT)), authenticationHeaderProvider.get());
-        HttpResponse<byte[]> response = HttpHelper.sendFileRequest(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, Content.DEFAULT, QueryModifier.DEFAULT)), authenticationHeaderProvider.get());
+        HttpResponse<byte[]> response = HttpRequestHelper.sendFileRequest(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
 
-        return HttpHelper.parseBody(response);
+        return HttpRequestHelper.parseBody(response);
     }
 
 
@@ -411,8 +412,8 @@ public abstract class BaseInterface {
      */
     protected <T> List<T> getAll(String path, SearchCriteria searchCriteria, Content content, QueryModifier modifier, Class<T> responseType)
             throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, PagingInfo.ALL, searchCriteria)), authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, PagingInfo.ALL, searchCriteria)), authenticationHeaderProvider.get());
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
             return deserializePage(response.body(), responseType).getContent();
@@ -436,8 +437,8 @@ public abstract class BaseInterface {
      */
     protected <T> List<T> getAllList(String path, Class<T> responseType)
             throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createGetRequest(resolve(path), authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(path), authenticationHeaderProvider.get());
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
             return new JsonApiDeserializer().readList(response.body(), responseType);
@@ -556,8 +557,8 @@ public abstract class BaseInterface {
      */
     protected <T> Page<T> getPage(String path, Content content, QueryModifier modifier, PagingInfo pagingInfo, SearchCriteria searchCriteria, Class<T> responseType)
             throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, pagingInfo, searchCriteria)), authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, pagingInfo, searchCriteria)), authenticationHeaderProvider.get());
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
             return deserializePage(response.body(), responseType);
@@ -655,11 +656,11 @@ public abstract class BaseInterface {
      */
     protected <T> T post(String path, Object entity, QueryModifier modifier, Content content, HttpStatus expectedStatusCode, Class<T> responseType)
             throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createPostRequest(
+        HttpRequest request = HttpRequestHelper.createPostRequest(
                 resolve(QueryHelper.apply(path, content, QueryModifier.DEFAULT)),
                 authenticationHeaderProvider.get(),
                 serialize(entity, content, modifier));
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.POST, response, expectedStatusCode);
         return parseBody(response, responseType);
     }
@@ -728,11 +729,11 @@ public abstract class BaseInterface {
      * @throws StatusCodeException if HTTP request returns invalid status code
      */
     protected void put(String path, Object entity, Content content, QueryModifier modifier) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createPutRequest(
+        HttpRequest request = HttpRequestHelper.createPutRequest(
                 resolve(QueryHelper.apply(path, content, modifier)),
                 authenticationHeaderProvider.get(),
                 serialize(entity, content, modifier));
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.PUT, response, HttpStatus.NO_CONTENT);
     }
 
@@ -746,8 +747,8 @@ public abstract class BaseInterface {
      * @throws StatusCodeException if HTTP request returns invalid status code
      */
     protected void putFile(String path, TypedInMemoryFile file) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createPutFileRequest(resolve(QueryHelper.apply(path, Content.DEFAULT, QueryModifier.DEFAULT)), authenticationHeaderProvider.get(), file);
-        HttpResponse<byte[]> response = HttpHelper.sendFileRequest(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createPutFileRequest(resolve(QueryHelper.apply(path, Content.DEFAULT, QueryModifier.DEFAULT)), authenticationHeaderProvider.get(), file);
+        HttpResponse<byte[]> response = HttpRequestHelper.sendFileRequest(httpClient, request);
         validateStatusCode(HttpMethod.PUT, response, HttpStatus.NO_CONTENT);
     }
 
@@ -817,11 +818,11 @@ public abstract class BaseInterface {
      * @throws StatusCodeException if HTTP request returns invalid status code
      */
     protected void patch(String path, Object entity, Content content, QueryModifier modifier) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createPatchRequest(
+        HttpRequest request = HttpRequestHelper.createPatchRequest(
                 resolve(QueryHelper.apply(path, content, modifier)),
                 authenticationHeaderProvider.get(),
                 serialize(entity, content, modifier));
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.PATCH, response, HttpStatus.NO_CONTENT);
     }
 
@@ -836,11 +837,11 @@ public abstract class BaseInterface {
      * @throws StatusCodeException if HTTP request returns invalid status code
      */
     protected void patchValue(String path, Object entity, QueryModifier modifier) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createPatchRequest(
+        HttpRequest request = HttpRequestHelper.createPatchRequest(
                 resolve(QueryHelper.apply(path, Content.VALUE, modifier)),
                 authenticationHeaderProvider.get(),
                 serializeEntity(entity));
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.PATCH, response, HttpStatus.NO_CONTENT);
     }
 
@@ -866,8 +867,8 @@ public abstract class BaseInterface {
      * @throws StatusCodeException if HTTP request returns invalid status code
      */
     protected void delete(String path, HttpStatus expectedStatus) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpHelper.createDeleteRequest(resolve(path), authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createDeleteRequest(resolve(path), authenticationHeaderProvider.get());
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.DELETE, response, expectedStatus);
     }
 
@@ -1051,7 +1052,13 @@ public abstract class BaseInterface {
         }
     }
 
-    public abstract static class BaseBuilder<I extends BaseInterface, B extends BaseBuilder<I, B>> {
+    /**
+     * Base builder for interface implementations to extend.
+     *
+     * @param <I> The type of the implementing interface
+     * @param <B> The type of the extending builder
+     */
+    public abstract static class AbstractBuilder<I extends BaseInterface, B extends AbstractBuilder<I, B>> {
         private HttpClient.Builder httpClientBuilder = HttpClient.newBuilder();
         protected URI endpoint;
         protected Supplier<String> authenticationHeaderProvider = NO_OP_AUTH_HEADER_PROVIDER;
@@ -1077,6 +1084,8 @@ public abstract class BaseInterface {
 
 
         /**
+         * Defines the endpoint of the AAS server.
+         *
          * @param endpoint Uri used to communicate with the FA³ST Service
          * @return builder
          */
@@ -1085,12 +1094,15 @@ public abstract class BaseInterface {
 
         /**
          * If called, the built interface will allow all (incl. self-signed) ssl certificates to communicate with AAS
-         * servers.<p>Will remove any previously defined http client.
+         * servers.
+         *
+         * <p>
+         * Will remove any previously defined http client.
          *
          * @return builder
          */
         public B useTrustAllHttpClient() {
-            HttpHelper.makeTrustAllCertificates(this.httpClientBuilder);
+            HttpClientHelper.makeTrustAllCertificates(this.httpClientBuilder);
             return getSelf();
         }
 
@@ -1103,15 +1115,18 @@ public abstract class BaseInterface {
          * @return builder
          */
         public B useBasicAuthentication(String username, String password) {
-            HttpHelper.addBasicAuthentication(this.httpClientBuilder, username, password);
+            HttpClientHelper.addBasicAuthentication(this.httpClientBuilder, username, password);
             return getSelf();
         }
 
 
         /**
          * Adds a supplier of an authentication header value. When requesting a resource from the AAS server, the authentication
-         * header will be retrieved and appended to the HTTP
-         * request. In terms of curl, this would mean: <p>{@code --header Authorization: authenticationHeaderProvider.get()}.
+         * header will be retrieved and appended to the HTTP request. In terms of curl, this would mean:
+         *
+         * <p>
+         * {@code --header Authorization: authenticationHeaderProvider.get()}.
+         *
          * <p>
          * Will remove any previously defined authentication header provider.
          *
@@ -1141,6 +1156,11 @@ public abstract class BaseInterface {
         protected abstract I buildConcrete();
 
 
+        /**
+         * Build the interface instance from the collected builder values.
+         *
+         * @return An instance of the interface implementation.
+         */
         public final I build() {
             validate();
             return getSelf().buildConcrete();

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
@@ -143,18 +143,6 @@ public abstract class BaseInterface {
 
 
     /**
-     * Creates a new instance.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    protected BaseInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        this(endpoint, HttpClient.newHttpClient(), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Executes a HTTP GET and parses the response body as {@code responseType}.
      *
      * @param <T> the result type

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
@@ -25,10 +25,10 @@ import de.fraunhofer.iosb.ilt.faaast.client.exception.NotFoundException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.UnauthorizedException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.UnsupportedStatusCodeException;
-import de.fraunhofer.iosb.ilt.faaast.client.query.SearchCriteria;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
+import de.fraunhofer.iosb.ilt.faaast.client.query.SearchCriteria;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
 import de.fraunhofer.iosb.ilt.faaast.client.util.QueryHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.DeserializationException;
 import de.fraunhofer.iosb.ilt.faaast.service.dataformat.SerializationException;
@@ -46,6 +46,11 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.exception.UnsupportedModifier
 import de.fraunhofer.iosb.ilt.faaast.service.model.value.ElementValue;
 import de.fraunhofer.iosb.ilt.faaast.service.typing.TypeInfo;
 import de.fraunhofer.iosb.ilt.faaast.service.util.EncodingHelper;
+import de.fraunhofer.iosb.ilt.faaast.service.util.Ensure;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.http.HttpClient;
@@ -56,17 +61,12 @@ import java.util.List;
 import java.util.Objects;
 import java.util.function.Supplier;
 
-import de.fraunhofer.iosb.ilt.faaast.service.util.Ensure;
-import org.json.JSONArray;
-import org.json.JSONException;
-import org.json.JSONObject;
-
 
 /**
- * Abstract base class providing core functionality for sending HTTP requests and handling API responses.
- * Supports GET, POST, PUT, PATCH and DELETE operations, deserialization of responses, and throws exceptions based on
- * status codes.
- * Subclasses extend these methods to interact with specific APIs.
+ * Abstract base class providing core functionality for sending HTTP requests and handling API responses. Supports GET,
+ * POST, PUT, PATCH and DELETE operations, deserialization of
+ * responses, and throws exceptions based on status codes. Subclasses extend these methods to interact with specific
+ * APIs.
  */
 public abstract class BaseInterface {
     private static final String URI_PATH_SEPERATOR = "/";
@@ -1052,14 +1052,28 @@ public abstract class BaseInterface {
     }
 
     public abstract static class BaseBuilder<I extends BaseInterface, B extends BaseBuilder<I, B>> {
-        protected HttpClient.Builder httpClientBuilder = HttpClient.newBuilder();
+        private HttpClient.Builder httpClientBuilder = HttpClient.newBuilder();
         protected URI endpoint;
         protected Supplier<String> authenticationHeaderProvider = NO_OP_AUTH_HEADER_PROVIDER;
 
+        /**
+         * Get a new instance of this builder type.
+         *
+         * @return A new instance of this builder type.
+         */
         public abstract B newInstance();
 
 
-        public abstract B getSelf();
+        /**
+         * Supply a custom HttpClient.Builder.
+         *
+         * @param builder Custom HttpClient.Builder
+         * @return builder
+         */
+        public B customHttpClientBuilder(HttpClient.Builder builder) {
+            this.httpClientBuilder = builder;
+            return getSelf();
+        }
 
 
         /**
@@ -1086,7 +1100,7 @@ public abstract class BaseInterface {
          *
          * @param username The username
          * @param password The password
-         * @return The builder
+         * @return builder
          */
         public B useBasicAuthentication(String username, String password) {
             HttpHelper.addBasicAuthentication(this.httpClientBuilder, username, password);
@@ -1114,6 +1128,9 @@ public abstract class BaseInterface {
         private void validate() {
             Ensure.requireNonNull(this.endpoint);
         }
+
+
+        protected abstract B getSelf();
 
 
         protected final HttpClient httpClient() {

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
@@ -412,7 +412,8 @@ public abstract class BaseInterface {
      */
     protected <T> List<T> getAll(String path, SearchCriteria searchCriteria, Content content, QueryModifier modifier, Class<T> responseType)
             throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, PagingInfo.ALL, searchCriteria)), authenticationHeaderProvider.get());
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, PagingInfo.ALL, searchCriteria)),
+                authenticationHeaderProvider.get());
         HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
@@ -557,7 +558,8 @@ public abstract class BaseInterface {
      */
     protected <T> Page<T> getPage(String path, Content content, QueryModifier modifier, PagingInfo pagingInfo, SearchCriteria searchCriteria, Class<T> responseType)
             throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, pagingInfo, searchCriteria)), authenticationHeaderProvider.get());
+        HttpRequest request = HttpRequestHelper.createGetRequest(resolve(QueryHelper.apply(path, content, modifier, pagingInfo, searchCriteria)),
+                authenticationHeaderProvider.get());
         HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         try {
@@ -747,7 +749,8 @@ public abstract class BaseInterface {
      * @throws StatusCodeException if HTTP request returns invalid status code
      */
     protected void putFile(String path, TypedInMemoryFile file) throws ConnectivityException, StatusCodeException {
-        HttpRequest request = HttpRequestHelper.createPutFileRequest(resolve(QueryHelper.apply(path, Content.DEFAULT, QueryModifier.DEFAULT)), authenticationHeaderProvider.get(), file);
+        HttpRequest request = HttpRequestHelper.createPutFileRequest(resolve(QueryHelper.apply(path, Content.DEFAULT, QueryModifier.DEFAULT)), authenticationHeaderProvider.get(),
+                file);
         HttpResponse<byte[]> response = HttpRequestHelper.sendFileRequest(httpClient, request);
         validateStatusCode(HttpMethod.PUT, response, HttpStatus.NO_CONTENT);
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterface.java
@@ -1068,19 +1068,22 @@ public abstract class BaseInterface {
          * @param builder Custom HttpClient.Builder
          * @return builder
          */
-        public B customHttpClientBuilder(HttpClient.Builder builder) {
+        public final B customHttpClientBuilder(HttpClient.Builder builder) {
             this.httpClientBuilder = builder;
             return getSelf();
         }
 
 
         /**
-         * Defines the endpoint of the AAS server.
+         * Defines the raw endpoint of the AAS server, i.e. *not* suffixed by the specific resource (e.g., /shells).
          *
          * @param endpoint Uri used to communicate with the FA³ST Service
          * @return builder
          */
-        public abstract B endpoint(URI endpoint);
+        public final B endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
 
 
         /**
@@ -1092,7 +1095,7 @@ public abstract class BaseInterface {
          *
          * @return builder
          */
-        public B useTrustAllHttpClient() {
+        public final B useTrustAllHttpClient() {
             HttpClientHelper.makeTrustAllCertificates(this.httpClientBuilder);
             return getSelf();
         }
@@ -1105,7 +1108,7 @@ public abstract class BaseInterface {
          * @param password The password
          * @return builder
          */
-        public B useBasicAuthentication(String username, String password) {
+        public final B useBasicAuthentication(String username, String password) {
             HttpClientHelper.addBasicAuthentication(this.httpClientBuilder, username, password);
             return getSelf();
         }
@@ -1125,26 +1128,10 @@ public abstract class BaseInterface {
          *            {authenticationHeaderProvider.get()}')
          * @return builder
          */
-        public B authenticationHeaderProvider(Supplier<String> authenticationHeaderProvider) {
+        public final B authenticationHeaderProvider(Supplier<String> authenticationHeaderProvider) {
             this.authenticationHeaderProvider = authenticationHeaderProvider;
             return getSelf();
         }
-
-
-        private void validate() {
-            Ensure.requireNonNull(this.endpoint);
-        }
-
-
-        protected abstract B getSelf();
-
-
-        protected final HttpClient httpClient() {
-            return this.httpClientBuilder.build();
-        }
-
-
-        protected abstract I buildConcrete();
 
 
         /**
@@ -1156,5 +1143,22 @@ public abstract class BaseInterface {
             validate();
             return getSelf().buildConcrete();
         }
+
+
+        protected abstract B getSelf();
+
+
+        protected abstract I buildConcrete();
+
+
+        protected final HttpClient httpClient() {
+            return this.httpClientBuilder.build();
+        }
+
+
+        private void validate() {
+            Ensure.requireNonNull(this.endpoint);
+        }
+
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -92,18 +92,6 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Concept Description Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public ConceptDescriptionRepositoryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Retrieves all Concept Descriptions from the server.
      *
      * @return List of all Concept Descriptions

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -25,6 +25,8 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
+import java.util.function.Supplier;
+
 import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
 
 
@@ -81,6 +83,18 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
      */
     public ConceptDescriptionRepositoryInterface(URI endpoint, boolean trustAllCertificates) {
         super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+    }
+
+
+    /**
+     * Creates a new Concept Description Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public ConceptDescriptionRepositoryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -42,11 +42,6 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
 
     private static final String API_PATH = "/concept-descriptions";
 
-    private ConceptDescriptionRepositoryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
-    }
-
-
     /**
      * Creates a new Concept Description Interface.
      *
@@ -272,7 +267,7 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
 
         @Override
         protected ConceptDescriptionRepositoryInterface buildConcrete() {
-            return new ConceptDescriptionRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new ConceptDescriptionRepositoryInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -42,6 +42,11 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
 
     private static final String API_PATH = "/concept-descriptions";
 
+    private ConceptDescriptionRepositoryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Concept Description Interface.
      *
@@ -273,5 +278,35 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
     @Override
     public void delete(String cdIdentifier) throws StatusCodeException, ConnectivityException {
         super.delete(idPath(cdIdentifier));
+    }
+
+    public static class Builder extends BaseBuilder<ConceptDescriptionRepositoryInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
+
+
+        @Override
+        public ConceptDescriptionRepositoryInterface buildConcrete() {
+            return new ConceptDescriptionRepositoryInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -306,7 +306,7 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
 
         @Override
         public ConceptDescriptionRepositoryInterface buildConcrete() {
-            return new ConceptDescriptionRepositoryInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new ConceptDescriptionRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -17,7 +17,7 @@ package de.fraunhofer.iosb.ilt.faaast.client.interfaces;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.query.ConceptDescriptionSearchCriteria;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.Content;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
@@ -87,7 +87,7 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public ConceptDescriptionRepositoryInterface(URI endpoint, boolean trustAllCertificates) {
-        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -280,7 +280,7 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
         super.delete(idPath(cdIdentifier));
     }
 
-    public static class Builder extends BaseBuilder<ConceptDescriptionRepositoryInterface, Builder> {
+    public static class Builder extends AbstractBuilder<ConceptDescriptionRepositoryInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -286,13 +286,6 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = endpoint;
-            return getSelf();
-        }
-
-
-        @Override
         public ConceptDescriptionRepositoryInterface buildConcrete() {
             return new ConceptDescriptionRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -22,17 +22,17 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.Content;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
+
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.ConceptDescription;
 
 
 /**
- * Interface for managing Concept Descriptions. It further provides access to the data of these elements through
- * the AAS Interface. A repository can host multiple entities.
+ * Interface for managing Concept Descriptions. It further provides access to the data of these elements through the AAS
+ * Interface. A repository can host multiple entities.
  *
  * <p>
  * Communication is handled via HTTP requests to a specified service URI.

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/ConceptDescriptionRepositoryInterface.java
@@ -270,23 +270,8 @@ public class ConceptDescriptionRepositoryInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<ConceptDescriptionRepositoryInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public ConceptDescriptionRepositoryInterface buildConcrete() {
+        protected ConceptDescriptionRepositoryInterface buildConcrete() {
             return new ConceptDescriptionRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -21,7 +21,6 @@ import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
 import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.client.util.HttpRequestHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.ServiceDescription;
-import org.eclipse.jetty.server.Session;
 
 import java.net.URI;
 import java.net.http.HttpClient;

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -18,7 +18,8 @@ import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpMethod;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpRequestHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.ServiceDescription;
 
 import java.net.URI;
@@ -85,7 +86,7 @@ public class DescriptionInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public DescriptionInterface(URI endpoint, boolean trustAllCertificates) {
-        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -118,13 +119,13 @@ public class DescriptionInterface extends BaseInterface {
      * @throws ConnectivityException if the connection to the server cannot be established
      */
     public ServiceDescription get() throws StatusCodeException, ConnectivityException {
-        HttpRequest request = HttpHelper.createGetRequest(endpoint, authenticationHeaderProvider.get());
-        HttpResponse<String> response = HttpHelper.send(httpClient, request);
+        HttpRequest request = HttpRequestHelper.createGetRequest(endpoint, authenticationHeaderProvider.get());
+        HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         return parseBody(response, ServiceDescription.class);
     }
 
-    public static class Builder extends BaseBuilder<DescriptionInterface, Builder> {
+    public static class Builder extends AbstractBuilder<DescriptionInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.util.function.Supplier;
 
 
 /**
@@ -84,6 +85,18 @@ public class DescriptionInterface extends BaseInterface {
 
 
     /**
+     * Creates a new Description Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public DescriptionInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
+    }
+
+
+    /**
      * Retrieves the self-describing information of a network resource (ServiceDescription) as a List of Strings.
      *
      * @return Requested self-describing information
@@ -100,7 +113,7 @@ public class DescriptionInterface extends BaseInterface {
      * @throws ConnectivityException if the connection to the server cannot be established
      */
     public ServiceDescription get() throws StatusCodeException, ConnectivityException {
-        HttpRequest request = HttpHelper.createGetRequest(endpoint);
+        HttpRequest request = HttpHelper.createGetRequest(endpoint, authenticationHeaderProvider.get());
         HttpResponse<String> response = HttpHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         return parseBody(response, ServiceDescription.class);

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -26,7 +26,6 @@ import java.net.URI;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
-import java.util.function.Supplier;
 
 
 /**
@@ -40,11 +39,6 @@ import java.util.function.Supplier;
 public class DescriptionInterface extends BaseInterface {
 
     private static final String API_PATH = "/description";
-
-    private DescriptionInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Description Interface.
@@ -107,7 +101,7 @@ public class DescriptionInterface extends BaseInterface {
      * @throws ConnectivityException if the connection to the server cannot be established
      */
     public ServiceDescription get() throws StatusCodeException, ConnectivityException {
-        HttpRequest request = HttpRequestHelper.createGetRequest(endpoint, authenticationHeaderProvider.get());
+        HttpRequest request = HttpRequestHelper.createGetRequest(endpoint);
         HttpResponse<String> response = HttpRequestHelper.send(httpClient, request);
         validateStatusCode(HttpMethod.GET, response, HttpStatus.OK);
         return parseBody(response, ServiceDescription.class);
@@ -117,7 +111,7 @@ public class DescriptionInterface extends BaseInterface {
 
         @Override
         protected DescriptionInterface buildConcrete() {
-            return new DescriptionInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new DescriptionInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -21,6 +21,7 @@ import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
 import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.client.util.HttpRequestHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.ServiceDescription;
+import org.eclipse.jetty.server.Session;
 
 import java.net.URI;
 import java.net.http.HttpClient;
@@ -42,7 +43,7 @@ public class DescriptionInterface extends BaseInterface {
     private static final String API_PATH = "/description";
 
     private DescriptionInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(endpoint, httpClient, authenticationHeaderProvider);
+        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
     }
 
 
@@ -127,13 +128,6 @@ public class DescriptionInterface extends BaseInterface {
         @Override
         public Builder getSelf() {
             return this;
-        }
-
-
-        @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = endpoint;
-            return getSelf();
         }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -150,7 +150,7 @@ public class DescriptionInterface extends BaseInterface {
 
         @Override
         public DescriptionInterface buildConcrete() {
-            return new DescriptionInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new DescriptionInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -40,6 +40,11 @@ public class DescriptionInterface extends BaseInterface {
 
     private static final String API_PATH = "/description";
 
+    private DescriptionInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(endpoint, httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Description Interface.
      *
@@ -119,4 +124,33 @@ public class DescriptionInterface extends BaseInterface {
         return parseBody(response, ServiceDescription.class);
     }
 
+    public static class Builder extends BaseBuilder<DescriptionInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
+
+
+        @Override
+        public DescriptionInterface buildConcrete() {
+            return new DescriptionInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
+    }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -91,18 +91,6 @@ public class DescriptionInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Description Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public DescriptionInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Retrieves the self-describing information of a network resource (ServiceDescription) as a List of Strings.
      *
      * @return Requested self-describing information

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/DescriptionInterface.java
@@ -116,23 +116,8 @@ public class DescriptionInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<DescriptionInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public DescriptionInterface buildConcrete() {
+        protected DescriptionInterface buildConcrete() {
             return new DescriptionInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -106,18 +106,6 @@ public class SubmodelInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Submodel API.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public SubmodelInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(endpoint, authenticationHeaderProvider);
-    }
-
-
-    /**
      * Retrieves the Submodel from the server.
      *
      * @return The requested Submodel object in standard format: deep structural depth and without blob value

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -940,23 +940,8 @@ public class SubmodelInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<SubmodelInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public SubmodelInterface buildConcrete() {
+        protected SubmodelInterface buildConcrete() {
             return new SubmodelInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -956,13 +956,6 @@ public class SubmodelInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = endpoint;
-            return getSelf();
-        }
-
-
-        @Override
         public SubmodelInterface buildConcrete() {
             return new SubmodelInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -33,7 +33,6 @@ import de.fraunhofer.iosb.ilt.faaast.service.typing.ElementValueTypeInfo;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultOperationRequest;
 import javax.xml.datatype.Duration;
@@ -55,11 +54,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
  * </p>
  */
 public class SubmodelInterface extends BaseInterface {
-
-    private SubmodelInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(endpoint, httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Submodel API.
@@ -942,7 +936,7 @@ public class SubmodelInterface extends BaseInterface {
 
         @Override
         protected SubmodelInterface buildConcrete() {
-            return new SubmodelInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new SubmodelInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -976,7 +976,7 @@ public class SubmodelInterface extends BaseInterface {
 
         @Override
         public SubmodelInterface buildConcrete() {
-            return new SubmodelInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new SubmodelInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -56,6 +56,11 @@ import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelElement;
  */
 public class SubmodelInterface extends BaseInterface {
 
+    private SubmodelInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(endpoint, httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Submodel API.
      *
@@ -943,5 +948,35 @@ public class SubmodelInterface extends BaseInterface {
 
     private static String invokePath(IdShortPath idShortPath) {
         return submodelElementIdPath(idShortPath) + "/invoke";
+    }
+
+    public static class Builder extends BaseBuilder<SubmodelInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
+
+
+        @Override
+        public SubmodelInterface buildConcrete() {
+            return new SubmodelInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -18,7 +18,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpStatus;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.IdShortPath;
 import de.fraunhofer.iosb.ilt.faaast.service.model.InMemoryFile;
 import de.fraunhofer.iosb.ilt.faaast.service.model.TypedInMemoryFile;
@@ -101,7 +101,7 @@ public class SubmodelInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public SubmodelInterface(URI endpoint, boolean trustAllCertificates) {
-        super(endpoint, trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(endpoint, trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -950,7 +950,7 @@ public class SubmodelInterface extends BaseInterface {
         return submodelElementIdPath(idShortPath) + "/invoke";
     }
 
-    public static class Builder extends BaseBuilder<SubmodelInterface, Builder> {
+    public static class Builder extends AbstractBuilder<SubmodelInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelInterface.java
@@ -33,6 +33,8 @@ import de.fraunhofer.iosb.ilt.faaast.service.typing.ElementValueTypeInfo;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
+import java.util.function.Supplier;
+
 import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultOperationRequest;
 import javax.xml.datatype.Duration;
 import org.eclipse.digitaltwin.aas4j.v3.model.OperationResult;
@@ -95,6 +97,18 @@ public class SubmodelInterface extends BaseInterface {
      */
     public SubmodelInterface(URI endpoint, boolean trustAllCertificates) {
         super(endpoint, trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+    }
+
+
+    /**
+     * Creates a new Submodel API.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public SubmodelInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(endpoint, authenticationHeaderProvider);
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -239,13 +239,6 @@ public class SubmodelRegistryInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = endpoint;
-            return getSelf();
-        }
-
-
-        @Override
         public SubmodelRegistryInterface buildConcrete() {
             return new SubmodelRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -41,7 +41,6 @@ public class SubmodelRegistryInterface extends BaseInterface {
 
     private static final String API_PATH = "/submodel-descriptors";
 
-
     private SubmodelRegistryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
         super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -16,7 +16,7 @@ package de.fraunhofer.iosb.ilt.faaast.client.interfaces;
 
 import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
 import org.eclipse.digitaltwin.aas4j.v3.model.SubmodelDescriptor;
@@ -86,7 +86,7 @@ public class SubmodelRegistryInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public SubmodelRegistryInterface(URI endpoint, boolean trustAllCertificates) {
-        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -233,7 +233,7 @@ public class SubmodelRegistryInterface extends BaseInterface {
         super.delete(idPath(submodelIdentifier));
     }
 
-    public static class Builder extends BaseBuilder<SubmodelRegistryInterface, Builder> {
+    public static class Builder extends AbstractBuilder<SubmodelRegistryInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -91,18 +91,6 @@ public class SubmodelRegistryInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Submodel Registry Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public SubmodelRegistryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Retrieves a list of all Submodel Descriptors.
      *
      * @return A list containing all Submodel Descriptors

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -24,6 +24,7 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelDescriptor;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
+import java.util.function.Supplier;
 
 
 /**
@@ -81,6 +82,18 @@ public class SubmodelRegistryInterface extends BaseInterface {
      */
     public SubmodelRegistryInterface(URI endpoint, boolean trustAllCertificates) {
         super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+    }
+
+
+    /**
+     * Creates a new Submodel Registry Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public SubmodelRegistryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -223,23 +223,8 @@ public class SubmodelRegistryInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<SubmodelRegistryInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public SubmodelRegistryInterface buildConcrete() {
+        protected SubmodelRegistryInterface buildConcrete() {
             return new SubmodelRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -260,7 +260,7 @@ public class SubmodelRegistryInterface extends BaseInterface {
 
         @Override
         public SubmodelRegistryInterface buildConcrete() {
-            return new SubmodelRegistryInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new SubmodelRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -41,6 +41,12 @@ public class SubmodelRegistryInterface extends BaseInterface {
 
     private static final String API_PATH = "/submodel-descriptors";
 
+
+    private SubmodelRegistryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Submodel Registry Interface.
      *
@@ -226,5 +232,35 @@ public class SubmodelRegistryInterface extends BaseInterface {
     @Override
     public void delete(String submodelIdentifier) throws StatusCodeException, ConnectivityException {
         super.delete(idPath(submodelIdentifier));
+    }
+
+    public static class Builder extends BaseBuilder<SubmodelRegistryInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
+
+
+        @Override
+        public SubmodelRegistryInterface buildConcrete() {
+            return new SubmodelRegistryInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRegistryInterface.java
@@ -24,7 +24,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.impl.DefaultSubmodelDescriptor;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
-import java.util.function.Supplier;
 
 
 /**
@@ -40,11 +39,6 @@ import java.util.function.Supplier;
 public class SubmodelRegistryInterface extends BaseInterface {
 
     private static final String API_PATH = "/submodel-descriptors";
-
-    private SubmodelRegistryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Submodel Registry Interface.
@@ -225,7 +219,7 @@ public class SubmodelRegistryInterface extends BaseInterface {
 
         @Override
         protected SubmodelRegistryInterface buildConcrete() {
-            return new SubmodelRegistryInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new SubmodelRegistryInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -25,7 +25,6 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
-import java.util.function.Supplier;
 
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
@@ -42,11 +41,6 @@ import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 public class SubmodelRepositoryInterface extends BaseInterface {
 
     private static final String API_PATH = "/submodels";
-
-    private SubmodelRepositoryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
-    }
-
 
     /**
      * Creates a new Submodel Repository API.
@@ -518,7 +512,7 @@ public class SubmodelRepositoryInterface extends BaseInterface {
 
         @Override
         protected SubmodelRepositoryInterface buildConcrete() {
-            return new SubmodelRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
+            return new SubmodelRepositoryInterface(endpoint, httpClient());
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -17,7 +17,7 @@ package de.fraunhofer.iosb.ilt.faaast.client.interfaces;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.ConnectivityException;
 import de.fraunhofer.iosb.ilt.faaast.client.exception.StatusCodeException;
 import de.fraunhofer.iosb.ilt.faaast.client.query.SubmodelSearchCriteria;
-import de.fraunhofer.iosb.ilt.faaast.client.util.HttpHelper;
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.Content;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.modifier.QueryModifier;
 import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.Page;
@@ -88,7 +88,7 @@ public class SubmodelRepositoryInterface extends BaseInterface {
      * @param trustAllCertificates Allows user to specify if all certificates (including self-signed) are trusted
      */
     public SubmodelRepositoryInterface(URI endpoint, boolean trustAllCertificates) {
-        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+        super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpClientHelper.newTrustAllCertificatesClient() : HttpClientHelper.newDefaultClient());
     }
 
 
@@ -526,7 +526,7 @@ public class SubmodelRepositoryInterface extends BaseInterface {
         return new SubmodelInterface(resolve(idPath(submodelId)), httpClient);
     }
 
-    public static class Builder extends BaseBuilder<SubmodelRepositoryInterface, Builder> {
+    public static class Builder extends AbstractBuilder<SubmodelRepositoryInterface, Builder> {
 
         private Builder() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -93,18 +93,6 @@ public class SubmodelRepositoryInterface extends BaseInterface {
 
 
     /**
-     * Creates a new Submodel Repository Interface.
-     *
-     * @param endpoint Uri used to communicate with the FA³ST service
-     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
-     *            {authenticationHeaderProvider.get()}')
-     */
-    public SubmodelRepositoryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
-        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
-    }
-
-
-    /**
      * Retrieves all Submodels.
      *
      * @return A List of all Submodels

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -43,7 +43,6 @@ public class SubmodelRepositoryInterface extends BaseInterface {
 
     private static final String API_PATH = "/submodels";
 
-
     private SubmodelRepositoryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
         super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
     }
@@ -553,7 +552,7 @@ public class SubmodelRepositoryInterface extends BaseInterface {
 
         @Override
         public SubmodelRepositoryInterface buildConcrete() {
-            return new SubmodelRepositoryInterface(endpoint, httpClient, authenticationHeaderProvider);
+            return new SubmodelRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -25,6 +25,8 @@ import de.fraunhofer.iosb.ilt.faaast.service.model.api.paging.PagingInfo;
 import java.net.URI;
 import java.net.http.HttpClient;
 import java.util.List;
+import java.util.function.Supplier;
+
 import org.eclipse.digitaltwin.aas4j.v3.model.Reference;
 import org.eclipse.digitaltwin.aas4j.v3.model.Submodel;
 
@@ -82,6 +84,18 @@ public class SubmodelRepositoryInterface extends BaseInterface {
      */
     public SubmodelRepositoryInterface(URI endpoint, boolean trustAllCertificates) {
         super(resolve(endpoint, API_PATH), trustAllCertificates ? HttpHelper.newTrustAllCertificatesClient() : HttpHelper.newDefaultClient());
+    }
+
+
+    /**
+     * Creates a new Submodel Repository Interface.
+     *
+     * @param endpoint Uri used to communicate with the FA³ST service
+     * @param authenticationHeaderProvider Supplier of authentication header value ('Authorization:
+     *            {authenticationHeaderProvider.get()}')
+     */
+    public SubmodelRepositoryInterface(URI endpoint, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), authenticationHeaderProvider);
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -532,13 +532,6 @@ public class SubmodelRepositoryInterface extends BaseInterface {
 
 
         @Override
-        public Builder endpoint(URI endpoint) {
-            this.endpoint = endpoint;
-            return getSelf();
-        }
-
-
-        @Override
         public SubmodelRepositoryInterface buildConcrete() {
             return new SubmodelRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -43,6 +43,12 @@ public class SubmodelRepositoryInterface extends BaseInterface {
 
     private static final String API_PATH = "/submodels";
 
+
+    private SubmodelRepositoryInterface(URI endpoint, HttpClient httpClient, Supplier<String> authenticationHeaderProvider) {
+        super(resolve(endpoint, API_PATH), httpClient, authenticationHeaderProvider);
+    }
+
+
     /**
      * Creates a new Submodel Repository API.
      *
@@ -519,5 +525,35 @@ public class SubmodelRepositoryInterface extends BaseInterface {
      */
     public SubmodelInterface getSubmodelInterface(String submodelId) {
         return new SubmodelInterface(resolve(idPath(submodelId)), httpClient);
+    }
+
+    public static class Builder extends BaseBuilder<SubmodelRepositoryInterface, Builder> {
+
+        private Builder() {}
+
+
+        @Override
+        public Builder newInstance() {
+            return new Builder();
+        }
+
+
+        @Override
+        public Builder getSelf() {
+            return this;
+        }
+
+
+        @Override
+        public Builder endpoint(URI endpoint) {
+            this.endpoint = endpoint;
+            return getSelf();
+        }
+
+
+        @Override
+        public SubmodelRepositoryInterface buildConcrete() {
+            return new SubmodelRepositoryInterface(endpoint, httpClient, authenticationHeaderProvider);
+        }
     }
 }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/SubmodelRepositoryInterface.java
@@ -516,23 +516,8 @@ public class SubmodelRepositoryInterface extends BaseInterface {
 
     public static class Builder extends AbstractBuilder<SubmodelRepositoryInterface, Builder> {
 
-        private Builder() {}
-
-
         @Override
-        public Builder newInstance() {
-            return new Builder();
-        }
-
-
-        @Override
-        public Builder getSelf() {
-            return this;
-        }
-
-
-        @Override
-        public SubmodelRepositoryInterface buildConcrete() {
+        protected SubmodelRepositoryInterface buildConcrete() {
             return new SubmodelRepositoryInterface(endpoint, httpClient(), authenticationHeaderProvider);
         }
     }

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpClientHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpClientHelper.java
@@ -17,7 +17,6 @@ package de.fraunhofer.iosb.ilt.faaast.client.util;
 import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 import java.net.http.HttpClient;
-import java.security.GeneralSecurityException;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpClientHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpClientHelper.java
@@ -18,6 +18,8 @@ import java.net.Authenticator;
 import java.net.PasswordAuthentication;
 import java.net.http.HttpClient;
 import java.security.GeneralSecurityException;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
 import java.security.cert.X509Certificate;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -125,7 +127,7 @@ public final class HttpClientHelper {
                     }
             }, new java.security.SecureRandom());
         }
-        catch (GeneralSecurityException e) {
+        catch (KeyManagementException | NoSuchAlgorithmException e) {
             throw new RuntimeException("failed to create HTTP client that trusts all certificates", e);
         }
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpClientHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpClientHelper.java
@@ -1,0 +1,134 @@
+/*
+ * Copyright (c) 2024 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.client.util;
+
+import java.net.Authenticator;
+import java.net.PasswordAuthentication;
+import java.net.http.HttpClient;
+import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+
+
+/**
+ * Utility class for creating a customized java.net.HttpClient.
+ */
+public final class HttpClientHelper {
+
+    private HttpClientHelper() {}
+
+
+    /**
+     * Creates a new default HTTP client.
+     *
+     * @return the new HTTP client
+     */
+    public static HttpClient newDefaultClient() {
+        return HttpClient.newHttpClient();
+    }
+
+
+    /**
+     * Creates a new HTTP client with basic username/password authentication.
+     *
+     * @param username the username
+     * @param password the password
+     * @return the new HTTP client
+     */
+    public static HttpClient newUsernamePasswordClient(String username, String password) {
+        return HttpClient.newBuilder()
+                .authenticator(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(username, password.toCharArray());
+                    }
+                }).build();
+    }
+
+
+    /**
+     * Creates a new HTTP client with basic username/password authentication.
+     *
+     * @param httpClientBuilder Builder to add basic auth to
+     * @param username the username
+     * @param password the password
+     */
+    public static void addBasicAuthentication(HttpClient.Builder httpClientBuilder, String username, String password) {
+        httpClientBuilder
+                .authenticator(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(username, password.toCharArray());
+                    }
+                });
+    }
+
+
+    /**
+     * Creates a new HTTP client that trusts all certificates (including self-signed ones).
+     *
+     * @return the new HTTP client
+     */
+    public static HttpClient newTrustAllCertificatesClient() {
+        return HttpClient.newBuilder()
+                .sslContext(trustAllSslContext())
+                .build();
+    }
+
+
+    /**
+     * Adds "trust-all-certificates" to a HttpClient builder.
+     *
+     * @param httpClientBuilder Builder to allow all certificates
+     */
+    public static void makeTrustAllCertificates(HttpClient.Builder httpClientBuilder) {
+        httpClientBuilder.sslContext(trustAllSslContext());
+    }
+
+
+    private static SSLContext trustAllSslContext() {
+        SSLContext sslContext;
+        try {
+            sslContext = SSLContext.getInstance("TLS");
+            sslContext.init(null, new TrustManager[] {
+                    new X509TrustManager() {
+                        @Override
+                        public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                            // intentionally empty
+                        }
+
+
+                        @Override
+                        public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                            // intentionally empty
+                        }
+
+
+                        @Override
+                        public X509Certificate[] getAcceptedIssuers() {
+                            return new X509Certificate[0];
+                        }
+                    }
+            }, new java.security.SecureRandom());
+        }
+        catch (GeneralSecurityException e) {
+            throw new RuntimeException("failed to create HTTP client that trusts all certificates", e);
+        }
+
+        return sslContext;
+    }
+}

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpHelper.java
@@ -90,13 +90,49 @@ public final class HttpHelper {
 
 
     /**
+     * Creates a new HTTP client with basic username/password authentication.
+     *
+     * @param httpClientBuilder Builder to add basic auth to
+     * @param username the username
+     * @param password the password
+     */
+    public static void addBasicAuthentication(HttpClient.Builder httpClientBuilder, String username, String password) {
+        httpClientBuilder
+                .authenticator(new Authenticator() {
+                    @Override
+                    protected PasswordAuthentication getPasswordAuthentication() {
+                        return new PasswordAuthentication(username, password.toCharArray());
+                    }
+                });
+    }
+
+
+    /**
      * Creates a new HTTP client that trusts all certificates (including self-signed ones).
      *
      * @return the new HTTP client
      */
     public static HttpClient newTrustAllCertificatesClient() {
+        return HttpClient.newBuilder()
+                .sslContext(trustAllSslContext())
+                .build();
+    }
+
+
+    /**
+     * Adds "trust-all-certificates" to a HttpClient builder.
+     *
+     * @param httpClientBuilder Builder to allow all certificates
+     */
+    public static void makeTrustAllCertificates(HttpClient.Builder httpClientBuilder) {
+        httpClientBuilder.sslContext(trustAllSslContext());
+    }
+
+
+    private static SSLContext trustAllSslContext() {
+        SSLContext sslContext;
         try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
+            sslContext = SSLContext.getInstance("TLS");
             sslContext.init(null, new TrustManager[] {
                     new X509TrustManager() {
                         @Override
@@ -117,13 +153,12 @@ public final class HttpHelper {
                         }
                     }
             }, new java.security.SecureRandom());
-            return HttpClient.newBuilder()
-                    .sslContext(sslContext)
-                    .build();
         }
         catch (GeneralSecurityException e) {
             throw new RuntimeException("failed to create HTTP client that trusts all certificates", e);
         }
+
+        return sslContext;
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpHelper.java
@@ -56,6 +56,7 @@ public final class HttpHelper {
     private static final String FILE_PARAMETER = "file";
     private static final String FILENAME_PARAMETER = "fileName";
     private static final String DEFAULT_FILENAME = "unknown";
+    private static final String AUTHORIZATION = "Authorization";
 
     private HttpHelper() {}
 
@@ -130,10 +131,15 @@ public final class HttpHelper {
      * Creates a GET request to the specified URI.
      *
      * @param uri the target URI to send the GET request to
+     * @param authHeader Additional authentication header
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createGetRequest(URI uri) {
-        return HttpRequest.newBuilder().uri(uri).GET().build();
+    public static HttpRequest createGetRequest(URI uri, String authHeader) {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(uri).GET();
+        if (authHeader != null) {
+            requestBuilder.header(AUTHORIZATION, authHeader);
+        }
+        return requestBuilder.build();
     }
 
 
@@ -141,15 +147,20 @@ public final class HttpHelper {
      * Creates a POST request to the specified URI with the provided request body.
      *
      * @param uri the target URI to send the POST request to
+     * @param authHeader Additional authentication header
      * @param body the request body as a string
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPostRequest(URI uri, String body) {
-        return HttpRequest.newBuilder()
+    public static HttpRequest createPostRequest(URI uri, String authHeader, String body) {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(uri)
                 .POST(HttpRequest.BodyPublishers.ofString(body))
-                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                .build();
+                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
+
+        if (authHeader != null) {
+            requestBuilder.header(AUTHORIZATION, authHeader);
+        }
+        return requestBuilder.build();
     }
 
 
@@ -157,15 +168,20 @@ public final class HttpHelper {
      * Sends a PUT request to the specified URI with the provided request body.
      *
      * @param uri the target URI to send the PUT request to
+     * @param authHeader Additional authentication header
      * @param body the request body as a string
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPutRequest(URI uri, String body) {
-        return HttpRequest.newBuilder()
+    public static HttpRequest createPutRequest(URI uri, String authHeader, String body) {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(uri)
                 .PUT(HttpRequest.BodyPublishers.ofString(body))
-                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                .build();
+                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
+
+        if (authHeader != null) {
+            requestBuilder.header(AUTHORIZATION, authHeader);
+        }
+        return requestBuilder.build();
     }
 
 
@@ -173,9 +189,11 @@ public final class HttpHelper {
      * Creates a PUT request for files to the specified URI.
      *
      * @param uri the target URI to send the GET request to
+     * @param authHeader Additional authentication header
+     * @param file File to send
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPutFileRequest(URI uri, TypedInMemoryFile file) {
+    public static HttpRequest createPutFileRequest(URI uri, String authHeader, TypedInMemoryFile file) {
         HttpEntity httpEntity = MultipartEntityBuilder.create()
                 .addTextBody(FILENAME_PARAMETER, file.getPath())
                 .addBinaryBody(FILE_PARAMETER,
@@ -184,11 +202,15 @@ public final class HttpHelper {
                         file.getPath())
                 .setBoundary(BOUNDARY)
                 .build();
-        return HttpRequest.newBuilder()
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(uri)
                 .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.MULTIPART_FORM_DATA.getMimeType() + "; boundary=" + BOUNDARY)
-                .PUT(HttpRequest.BodyPublishers.ofInputStream(LambdaExceptionHelper.wrap(httpEntity::getContent)))
-                .build();
+                .PUT(HttpRequest.BodyPublishers.ofInputStream(LambdaExceptionHelper.wrap(httpEntity::getContent)));
+
+        if (authHeader != null) {
+            requestBuilder.header(AUTHORIZATION, authHeader);
+        }
+        return requestBuilder.build();
     }
 
 
@@ -196,15 +218,20 @@ public final class HttpHelper {
      * Creates a PATCH request to the specified URI with the provided request body.
      *
      * @param uri the target URI to send the PATCH request to
+     * @param authHeader Additional authentication header
      * @param body the request body as a string
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPatchRequest(URI uri, String body) {
-        return HttpRequest.newBuilder()
+    public static HttpRequest createPatchRequest(URI uri, String authHeader, String body) {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
                 .uri(uri)
                 .method(HttpMethod.PATCH.name(), HttpRequest.BodyPublishers.ofString(body))
-                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
-                .build();
+                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
+
+        if (authHeader != null) {
+            requestBuilder.header(AUTHORIZATION, authHeader);
+        }
+        return requestBuilder.build();
     }
 
 
@@ -212,10 +239,16 @@ public final class HttpHelper {
      * Creates a DELETE request to the specified URI.
      *
      * @param uri the target URI to send the DELETE request to
+     * @param authHeader Additional authentication header
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createDeleteRequest(URI uri) {
-        return HttpRequest.newBuilder().uri(uri).DELETE().build();
+    public static HttpRequest createDeleteRequest(URI uri, String authHeader) {
+        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(uri).DELETE();
+
+        if (authHeader != null) {
+            requestBuilder.header(AUTHORIZATION, authHeader);
+        }
+        return requestBuilder.build();
     }
 
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
@@ -49,7 +49,6 @@ public final class HttpRequestHelper {
     private static final String FILE_PARAMETER = "file";
     private static final String FILENAME_PARAMETER = "fileName";
     private static final String DEFAULT_FILENAME = "unknown";
-    private static final String AUTHORIZATION = "Authorization";
 
     private HttpRequestHelper() {}
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
@@ -14,7 +14,6 @@
  */
 package de.fraunhofer.iosb.ilt.faaast.client.util;
 
-import static java.lang.Thread.currentThread;
 import static org.apache.commons.fileupload.FileUploadBase.CONTENT_DISPOSITION;
 
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpMethod;

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
@@ -14,6 +14,7 @@
  */
 package de.fraunhofer.iosb.ilt.faaast.client.util;
 
+import static java.lang.Thread.currentThread;
 import static org.apache.commons.fileupload.FileUploadBase.CONTENT_DISPOSITION;
 
 import de.fraunhofer.iosb.ilt.faaast.client.http.HttpMethod;
@@ -159,8 +160,12 @@ public final class HttpRequestHelper {
         try {
             return httpClient.send(request, HttpResponse.BodyHandlers.ofString());
         }
-        catch (IOException | InterruptedException e) {
+        catch (IOException e) {
             throw new ConnectivityException(e);
+        }
+        catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new ConnectivityException("Request interrupted", e);
         }
     }
 

--- a/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
+++ b/core/src/main/java/de/fraunhofer/iosb/ilt/faaast/client/util/HttpRequestHelper.java
@@ -58,14 +58,10 @@ public final class HttpRequestHelper {
      * Creates a GET request to the specified URI.
      *
      * @param uri the target URI to send the GET request to
-     * @param authHeader Additional authentication header
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createGetRequest(URI uri, String authHeader) {
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(uri).GET();
-        decorate(requestBuilder, authHeader);
-
-        return requestBuilder.build();
+    public static HttpRequest createGetRequest(URI uri) {
+        return HttpRequest.newBuilder().uri(uri).GET().build();
     }
 
 
@@ -73,19 +69,15 @@ public final class HttpRequestHelper {
      * Creates a POST request to the specified URI with the provided request body.
      *
      * @param uri the target URI to send the POST request to
-     * @param authHeader Additional authentication header
      * @param body the request body as a string
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPostRequest(URI uri, String authHeader, String body) {
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+    public static HttpRequest createPostRequest(URI uri, String body) {
+        return HttpRequest.newBuilder()
                 .uri(uri)
                 .POST(HttpRequest.BodyPublishers.ofString(body))
-                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
-
-        decorate(requestBuilder, authHeader);
-
-        return requestBuilder.build();
+                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .build();
     }
 
 
@@ -93,19 +85,15 @@ public final class HttpRequestHelper {
      * Sends a PUT request to the specified URI with the provided request body.
      *
      * @param uri the target URI to send the PUT request to
-     * @param authHeader Additional authentication header
      * @param body the request body as a string
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPutRequest(URI uri, String authHeader, String body) {
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+    public static HttpRequest createPutRequest(URI uri, String body) {
+        return HttpRequest.newBuilder()
                 .uri(uri)
                 .PUT(HttpRequest.BodyPublishers.ofString(body))
-                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
-
-        decorate(requestBuilder, authHeader);
-
-        return requestBuilder.build();
+                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .build();
     }
 
 
@@ -113,11 +101,9 @@ public final class HttpRequestHelper {
      * Creates a PUT request for files to the specified URI.
      *
      * @param uri the target URI to send the GET request to
-     * @param authHeader Additional authentication header
-     * @param file File to send
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPutFileRequest(URI uri, String authHeader, TypedInMemoryFile file) {
+    public static HttpRequest createPutFileRequest(URI uri, TypedInMemoryFile file) {
         HttpEntity httpEntity = MultipartEntityBuilder.create()
                 .addTextBody(FILENAME_PARAMETER, file.getPath())
                 .addBinaryBody(FILE_PARAMETER,
@@ -126,14 +112,11 @@ public final class HttpRequestHelper {
                         file.getPath())
                 .setBoundary(BOUNDARY)
                 .build();
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+        return HttpRequest.newBuilder()
                 .uri(uri)
                 .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.MULTIPART_FORM_DATA.getMimeType() + "; boundary=" + BOUNDARY)
-                .PUT(HttpRequest.BodyPublishers.ofInputStream(LambdaExceptionHelper.wrap(httpEntity::getContent)));
-
-        decorate(requestBuilder, authHeader);
-
-        return requestBuilder.build();
+                .PUT(HttpRequest.BodyPublishers.ofInputStream(LambdaExceptionHelper.wrap(httpEntity::getContent)))
+                .build();
     }
 
 
@@ -141,19 +124,15 @@ public final class HttpRequestHelper {
      * Creates a PATCH request to the specified URI with the provided request body.
      *
      * @param uri the target URI to send the PATCH request to
-     * @param authHeader Additional authentication header
      * @param body the request body as a string
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createPatchRequest(URI uri, String authHeader, String body) {
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder()
+    public static HttpRequest createPatchRequest(URI uri, String body) {
+        return HttpRequest.newBuilder()
                 .uri(uri)
                 .method(HttpMethod.PATCH.name(), HttpRequest.BodyPublishers.ofString(body))
-                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType());
-
-        decorate(requestBuilder, authHeader);
-
-        return requestBuilder.build();
+                .header(HttpConstants.HEADER_CONTENT_TYPE, ContentType.APPLICATION_JSON.getMimeType())
+                .build();
     }
 
 
@@ -161,15 +140,10 @@ public final class HttpRequestHelper {
      * Creates a DELETE request to the specified URI.
      *
      * @param uri the target URI to send the DELETE request to
-     * @param authHeader Additional authentication header
      * @return the HttpResponse containing the response body as a string
      */
-    public static HttpRequest createDeleteRequest(URI uri, String authHeader) {
-        HttpRequest.Builder requestBuilder = HttpRequest.newBuilder().uri(uri).DELETE();
-
-        decorate(requestBuilder, authHeader);
-
-        return requestBuilder.build();
+    public static HttpRequest createDeleteRequest(URI uri) {
+        return HttpRequest.newBuilder().uri(uri).DELETE().build();
     }
 
 
@@ -228,13 +202,6 @@ public final class HttpRequestHelper {
         return new InMemoryFile.Builder()
                 .content(httpResponse.body())
                 .path(extractName(contentDispositionHeader)).build();
-    }
-
-
-    private static void decorate(HttpRequest.Builder requestBuilder, String authenticationHeaderValue) {
-        if (authenticationHeaderValue != null) {
-            requestBuilder.header(AUTHORIZATION, authenticationHeaderValue);
-        }
     }
 
 

--- a/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBasedTest.java
+++ b/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBasedTest.java
@@ -1,0 +1,215 @@
+/*
+ * Copyright (c) 2024 Fraunhofer IOSB, eine rechtlich nicht selbstaendige
+ * Einrichtung der Fraunhofer-Gesellschaft zur Foerderung der angewandten
+ * Forschung e.V.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package de.fraunhofer.iosb.ilt.faaast.client.http;
+
+import de.fraunhofer.iosb.ilt.faaast.client.util.HttpClientHelper;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.temporal.ChronoUnit;
+import java.util.concurrent.ExecutionException;
+import java.util.function.BiFunction;
+import java.util.function.Supplier;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+
+public class HttpClientTokenBasedTest {
+    private static MockWebServer server;
+
+    @Before
+    public void setup() throws IOException {
+        server = new MockWebServer();
+        server.start();
+    }
+
+
+    @Test
+    public void send_withCorrectAuthHeader_isAddedToRequest() throws InterruptedException {
+        HttpClient httpClient = HttpClientHelper.newDefaultClient();
+        Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        HttpClient testSubject = new HttpClientTokenBased(httpClient, supplier);
+        HttpRequest request = ordinaryGetRequest();
+
+        RecordedRequest recordedRequest = sendAndRecordRequest(wrapSend(testSubject), request);
+
+        assertRequest(request, recordedRequest, supplier.get());
+    }
+
+
+    @Test
+    public void sendAsync_withCorrectAuthHeader_isAddedToRequest() throws InterruptedException {
+        HttpClient httpClient = HttpClientHelper.newDefaultClient();
+        Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        HttpClient testSubject = new HttpClientTokenBased(httpClient, supplier);
+        HttpRequest request = ordinaryGetRequest();
+
+        RecordedRequest recordedRequest = sendAndRecordRequest(wrapSendAsync(testSubject), request);
+
+        assertRequest(request, recordedRequest, supplier.get());
+    }
+
+
+    @Test
+    public void sendAsyncWithPushPromise_withCorrectAuthHeader_isAddedToRequest() throws InterruptedException {
+        HttpClient httpClient = HttpClientHelper.newDefaultClient();
+        Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        HttpClient testSubject = new HttpClientTokenBased(httpClient, supplier);
+        HttpRequest request = ordinaryGetRequest();
+
+        RecordedRequest recordedRequest = sendAndRecordRequest(wrapSendAsyncWithPushPromise(testSubject), request);
+
+        assertRequest(request, recordedRequest, supplier.get());
+    }
+
+
+    @Test
+    public void send_supplyingNull_doesNotFail() throws InterruptedException {
+        HttpClient httpClient = HttpClientHelper.newDefaultClient();
+        Supplier<String> supplier = () -> null;
+
+        HttpClient testSubject = new HttpClientTokenBased(httpClient, supplier);
+        HttpRequest request = ordinaryGetRequest();
+
+        RecordedRequest recordedRequest = sendAndRecordRequest(wrapSend(testSubject), request);
+
+        assertRequest(request, recordedRequest, supplier.get());
+    }
+
+
+    @Test
+    public void send_noAdditionalHeaders_doesNotFail() throws InterruptedException {
+        HttpClient httpClient = HttpClientHelper.newDefaultClient();
+        Supplier<String> supplier = () -> "test";
+
+        HttpClient testSubject = new HttpClientTokenBased(httpClient, supplier);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://localhost:%s/mypath", server.getPort())))
+                .GET()
+                .timeout(Duration.of(1234, ChronoUnit.SECONDS))
+                .build();
+
+        RecordedRequest recordedRequest = sendAndRecordRequest(wrapSend(testSubject), request);
+
+        assertRequest(request, recordedRequest, supplier.get());
+    }
+
+
+    @Test
+    public void validate_allSettings_sameAsDecoratedHttpClient() {
+        HttpClient httpClient = HttpClientHelper.newDefaultClient();
+        Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
+
+        HttpClient testSubject = new HttpClientTokenBased(httpClient, supplier);
+
+        assertEquals(httpClient.authenticator(), testSubject.authenticator());
+        assertEquals(httpClient.connectTimeout(), testSubject.connectTimeout());
+        assertEquals(httpClient.cookieHandler(), testSubject.cookieHandler());
+        assertEquals(httpClient.executor(), testSubject.executor());
+        assertEquals(httpClient.followRedirects(), testSubject.followRedirects());
+        assertEquals(httpClient.proxy(), testSubject.proxy());
+        assertEquals(httpClient.sslContext(), testSubject.sslContext());
+        assertArrayEquals(httpClient.sslParameters().getCipherSuites(), testSubject.sslParameters().getCipherSuites());
+        assertArrayEquals(httpClient.sslParameters().getProtocols(), testSubject.sslParameters().getProtocols());
+        assertEquals(httpClient.sslParameters().getWantClientAuth(), testSubject.sslParameters().getWantClientAuth());
+        assertEquals(httpClient.sslParameters().getNeedClientAuth(), testSubject.sslParameters().getNeedClientAuth());
+        assertEquals(httpClient.sslParameters().getEndpointIdentificationAlgorithm(), testSubject.sslParameters().getEndpointIdentificationAlgorithm());
+        assertEquals(httpClient.sslParameters().getAlgorithmConstraints(), testSubject.sslParameters().getAlgorithmConstraints());
+        assertEquals(httpClient.sslParameters().getSNIMatchers(), testSubject.sslParameters().getSNIMatchers());
+        assertEquals(httpClient.sslParameters().getServerNames(), testSubject.sslParameters().getServerNames());
+        assertEquals(httpClient.sslParameters().getUseCipherSuitesOrder(), testSubject.sslParameters().getUseCipherSuitesOrder());
+        assertEquals(httpClient.sslParameters().getEnableRetransmissions(), testSubject.sslParameters().getEnableRetransmissions());
+        assertEquals(httpClient.sslParameters().getMaximumPacketSize(), testSubject.sslParameters().getMaximumPacketSize());
+        assertArrayEquals(httpClient.sslParameters().getApplicationProtocols(), testSubject.sslParameters().getApplicationProtocols());
+        assertEquals(httpClient.version(), testSubject.version());
+    }
+
+
+    private BiFunction<HttpRequest, HttpResponse.BodyHandler<?>, HttpResponse<?>> wrapSend(HttpClient client) {
+        return (request, responseHandler) -> {
+            try {
+                return client.send(request, responseHandler);
+            }
+            catch (IOException | InterruptedException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+
+    private BiFunction<HttpRequest, HttpResponse.BodyHandler<?>, HttpResponse<?>> wrapSendAsync(HttpClient client) {
+        return (request, responseHandler) -> {
+            try {
+                return client.sendAsync(request, responseHandler).get();
+            }
+            catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+
+    private BiFunction<HttpRequest, HttpResponse.BodyHandler<?>, HttpResponse<?>> wrapSendAsyncWithPushPromise(HttpClient client) {
+        return (request, responseHandler) -> {
+            try {
+                return client.sendAsync(request, responseHandler, null).get();
+            }
+            catch (InterruptedException | ExecutionException e) {
+                throw new RuntimeException(e);
+            }
+        };
+    }
+
+
+    private RecordedRequest sendAndRecordRequest(BiFunction<HttpRequest, HttpResponse.BodyHandler<?>, HttpResponse<?>> handler, HttpRequest request)
+            throws InterruptedException {
+        server.enqueue(new MockResponse());
+        handler.apply(request, HttpResponse.BodyHandlers.discarding());
+        return server.takeRequest();
+    }
+
+
+    private void assertRequest(HttpRequest sent, RecordedRequest recorded, String authenticationHeaderValue) {
+        assertEquals(authenticationHeaderValue, recorded.getHeader("Authorization"));
+        sent.headers().map().forEach((k, vs) -> vs.forEach(v -> assertEquals(v, recorded.getHeader(k))));
+        assertEquals(0, recorded.getBodySize());
+        assertNotNull(recorded.getRequestUrl());
+        assertEquals(sent.uri().getPath(), recorded.getPath());
+    }
+
+
+    private HttpRequest ordinaryGetRequest() {
+        return HttpRequest.newBuilder()
+                .uri(URI.create(String.format("http://localhost:%s/mypath", server.getPort())))
+                .GET()
+                .headers("Accept", "application/json")
+                .timeout(Duration.of(1234, ChronoUnit.SECONDS))
+                .build();
+    }
+}

--- a/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBasedTest.java
+++ b/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/client/http/HttpClientTokenBasedTest.java
@@ -35,6 +35,7 @@ import java.util.function.Supplier;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.fail;
 
 
 public class HttpClientTokenBasedTest {
@@ -48,7 +49,7 @@ public class HttpClientTokenBasedTest {
 
 
     @Test
-    public void send_withCorrectAuthHeader_isAddedToRequest() throws InterruptedException {
+    public void sendWithCorrectAuthHeaderIsAddedToRequest() throws InterruptedException {
         HttpClient httpClient = HttpClientHelper.newDefaultClient();
         Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -62,7 +63,7 @@ public class HttpClientTokenBasedTest {
 
 
     @Test
-    public void sendAsync_withCorrectAuthHeader_isAddedToRequest() throws InterruptedException {
+    public void sendAsyncWithCorrectAuthHeaderIsAddedToRequest() throws InterruptedException {
         HttpClient httpClient = HttpClientHelper.newDefaultClient();
         Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -76,7 +77,7 @@ public class HttpClientTokenBasedTest {
 
 
     @Test
-    public void sendAsyncWithPushPromise_withCorrectAuthHeader_isAddedToRequest() throws InterruptedException {
+    public void sendAsyncWithPushPromiseWithCorrectAuthHeaderIsAddedToRequest() throws InterruptedException {
         HttpClient httpClient = HttpClientHelper.newDefaultClient();
         Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -90,7 +91,7 @@ public class HttpClientTokenBasedTest {
 
 
     @Test
-    public void send_supplyingNull_doesNotFail() throws InterruptedException {
+    public void sendSupplyingNullDoesNotFail() throws InterruptedException {
         HttpClient httpClient = HttpClientHelper.newDefaultClient();
         Supplier<String> supplier = () -> null;
 
@@ -104,7 +105,7 @@ public class HttpClientTokenBasedTest {
 
 
     @Test
-    public void send_noAdditionalHeaders_doesNotFail() throws InterruptedException {
+    public void sendNoAdditionalHeadersDoesNotFail() throws InterruptedException {
         HttpClient httpClient = HttpClientHelper.newDefaultClient();
         Supplier<String> supplier = () -> "test";
 
@@ -122,7 +123,7 @@ public class HttpClientTokenBasedTest {
 
 
     @Test
-    public void validate_allSettings_sameAsDecoratedHttpClient() {
+    public void validateAllSettingsSameAsDecoratedHttpClient() {
         HttpClient httpClient = HttpClientHelper.newDefaultClient();
         Supplier<String> supplier = () -> "Bearer eyxyZABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
@@ -157,7 +158,8 @@ public class HttpClientTokenBasedTest {
                 return client.send(request, responseHandler);
             }
             catch (IOException | InterruptedException e) {
-                throw new RuntimeException(e);
+                fail();
+                return null;
             }
         };
     }
@@ -169,7 +171,8 @@ public class HttpClientTokenBasedTest {
                 return client.sendAsync(request, responseHandler).get();
             }
             catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
+                fail();
+                return null;
             }
         };
     }
@@ -181,7 +184,8 @@ public class HttpClientTokenBasedTest {
                 return client.sendAsync(request, responseHandler, null).get();
             }
             catch (InterruptedException | ExecutionException e) {
-                throw new RuntimeException(e);
+                fail();
+                return null;
             }
         };
     }

--- a/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterfaceTest.java
+++ b/core/src/test/java/de/fraunhofer/iosb/ilt/faaast/client/interfaces/BaseInterfaceTest.java
@@ -44,7 +44,9 @@ public class BaseInterfaceTest {
     public void setup() throws IOException {
         server = new MockWebServer();
         server.start();
-        concreteSubclass = new SubmodelRepositoryInterface(server.url("api/v3.0").uri());
+        concreteSubclass = new SubmodelRepositoryInterface.Builder()
+                .endpoint(server.url("api/v3.0").uri())
+                .build();
     }
 
 


### PR DESCRIPTION
* Adds option to pass **authentication header value** to AAS server requests
  * This is done with a java.net.HttpClient decorator injecting headers into send* requests
  * Supplier<String> will provide the header value for the `Authorization: ...` header
* Adds **Builder** pattern to interfaces
  * Easier customization of interfaces
* Splits up `HttpHelper` into `HttpRequestHelper` and `HttpClientHelper`
* Also adds new test cases for HttpClient decorator
